### PR TITLE
Remove unsafe

### DIFF
--- a/src/script/bc.rs
+++ b/src/script/bc.rs
@@ -1,4 +1,3 @@
-use std::mem::transmute;
 use std::convert::TryInto;
 use std::collections::{VecDeque, HashSet};
 use std::cell::RefCell;
@@ -457,7 +456,7 @@ impl Arg {
     }
 
     fn as_signed(self) -> i32 {
-        unsafe { transmute(self.0) }
+        self.0 as i32
     }
 
     #[allow(clippy::if_same_then_else)]

--- a/src/script/parse/unparse.rs
+++ b/src/script/parse/unparse.rs
@@ -154,7 +154,7 @@ impl Unparse for Expression {
                 }
 
                 // It's an int. Format it as signed.
-                format!("{}", unsafe { std::mem::transmute::<u32, i32>(maybe_ptr) })
+                format!("{}", maybe_ptr as i32)
             },
             Expression::LiteralFloat(f) => format!("{}", f),
             Expression::LiteralBool(b)  => format!("{}", b),


### PR DESCRIPTION
Integer casts are safe and work how you'd expect. Now there is no `unsafe` anywhere!