### PR TITLE
Clean up workspace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 *.n64
 *.v64
 *.z64
-/target
+/ztar-rod/target
 /mod
 **/*.rs.bk

--- a/ztar-rod/Cargo.toml
+++ b/ztar-rod/Cargo.toml
@@ -14,8 +14,3 @@ pest_derive = "2.1.0"
 lazy_static = "1.3.0"
 ascii = "0.9.1"
 png = "0.14.1"
-
-[profile.release]
-opt-level = 'z'
-#codegen-units = 1
-panic = 'abort'


### PR DESCRIPTION
Fixes `.gitignore`, moving the `target` build directory.

Removes release profile options from `Cargo.toml` entirely. Cargo says:

> warning: profiles for the non root package will be ignored, specify profiles at the workspace root

The other option is to move the profile as instructed.

Most binary projects, even speed-critical ones like [`ripgrep`](https://github.com/BurntSushi/ripgrep/blob/08ae4da2b79cc4e59a43e98f61ce4fd6e0adc81d/Cargo.toml), don't change the default release profile. Best to avoid the extra code.